### PR TITLE
service/dap: Add support for debug and test modes

### DIFF
--- a/_fixtures/buildtest/main_test.go
+++ b/_fixtures/buildtest/main_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -1,0 +1,73 @@
+// Package gobuild provides utilities for building programs and tests
+// for the debugging session.
+
+package gobuild
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/go-delve/delve/pkg/config"
+	"github.com/go-delve/delve/pkg/goversion"
+)
+
+// Remove the file at path and issue a warning to stderr if this fails.
+// This can be used to remove the temporary binary generated for the session.
+func Remove(path string) {
+	err := os.Remove(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not remove %v: %v\n", path, err)
+	}
+}
+
+// OptFlags generates default build flags to run off optimization and inlining.
+func OptFlags(args []string) []string {
+	// after go1.9 building with -gcflags='-N -l' and -a simultaneously works.
+	// after go1.10 specifying -a is unnecessary because of the new caching strategy,
+	// but we should pass -gcflags=all=-N -l to have it applied to all packages
+	// see https://github.com/golang/go/commit/5993251c015dfa1e905bdf44bdb41572387edf90
+
+	ver, _ := goversion.Installed()
+	switch {
+	case ver.Major < 0 || ver.AfterOrEqual(goversion.GoVersion{1, 10, -1, 0, 0, ""}):
+		args = append(args, "-gcflags", "all=-N -l")
+	case ver.AfterOrEqual(goversion.GoVersion{1, 9, -1, 0, 0, ""}):
+		args = append(args, "-gcflags", "-N -l", "-a")
+	default:
+		args = append(args, "-gcflags", "-N -l")
+	}
+	return args
+}
+
+// GoBuild builds non-test files in 'pkgs' with the specified 'buildflags'
+// and writes the output at 'debugname'.
+func GoBuild(debugname string, pkgs []string, buildflags string) error {
+	args := []string{"-o", debugname}
+	args = OptFlags(args)
+	if buildflags != "" {
+		args = append(args, config.SplitQuotedFields(buildflags, '\'')...)
+	}
+	args = append(args, pkgs...)
+	return gocommand("build", args...)
+}
+
+// GoBuild builds test files 'pkgs' with the specified 'buildflags'
+// and writes the output at 'debugname'.
+func GoTestBuild(debugname string, pkgs []string, buildflags string) error {
+	args := []string{"-c", "-o", debugname}
+	args = OptFlags(args)
+	if buildflags != "" {
+		args = append(args, config.SplitQuotedFields(buildflags, '\'')...)
+	}
+	args = append(args, pkgs...)
+	return gocommand("test", args...)
+}
+
+func gocommand(command string, args ...string) error {
+	allargs := []string{command}
+	allargs = append(allargs, args...)
+	goBuild := exec.Command("go", allargs...)
+	goBuild.Stderr = os.Stderr
+	return goBuild.Run()
+}

--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -21,7 +21,7 @@ func Remove(path string) {
 	}
 }
 
-// OptFlags generates default build flags to run off optimization and inlining.
+// OptFlags generates default build flags to turn off optimization and inlining.
 func OptFlags(args []string) []string {
 	// after go1.9 building with -gcflags='-N -l' and -a simultaneously works.
 	// after go1.10 specifying -a is unnecessary because of the new caching strategy,

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -137,12 +137,16 @@ func (c *Client) InitializeRequest() {
 }
 
 // LaunchRequest sends a 'launch' request.
-func (c *Client) LaunchRequest(program string, stopOnEntry bool) {
+// Takes arguments as interface{} to allow for testing of values
+// of unexpected types since the launch flags are implementation-specific
+// and not part of the official protocol.
+func (c *Client) LaunchRequest(mode interface{}, program interface{}, output interface{}, stopOnEntry interface{}) {
 	request := &dap.LaunchRequest{Request: *c.newRequest("launch")}
 	request.Arguments = map[string]interface{}{
 		"request":     "launch",
-		"mode":        "exec",
+		"mode":        mode,
 		"program":     program,
+		"output":      output,
 		"stopOnEntry": stopOnEntry,
 	}
 	c.send(request)

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -136,19 +136,24 @@ func (c *Client) InitializeRequest() {
 	c.send(request)
 }
 
-// LaunchRequest sends a 'launch' request.
-// Takes arguments as interface{} to allow for testing of values
-// of unexpected types since the launch flags are implementation-specific
-// and not part of the official protocol.
-func (c *Client) LaunchRequest(mode interface{}, program interface{}, output interface{}, stopOnEntry interface{}) {
+// LaunchRequest sends a 'launch' request with the specified args.
+func (c *Client) LaunchRequest(mode string, program string, stopOnEntry bool) {
 	request := &dap.LaunchRequest{Request: *c.newRequest("launch")}
 	request.Arguments = map[string]interface{}{
 		"request":     "launch",
 		"mode":        mode,
 		"program":     program,
-		"output":      output,
 		"stopOnEntry": stopOnEntry,
 	}
+	c.send(request)
+}
+
+// LaunchRequestWithArgs takes a map of untyped implementation-specific
+// arguments to send a 'launch' request. This version can be used to
+// test for values of unexpected types or unspecified values.
+func (c *Client) LaunchRequestWithArgs(arguments map[string]interface{}) {
+	request := &dap.LaunchRequest{Request: *c.newRequest("launch")}
+	request.Arguments = arguments
 	c.send(request)
 }
 

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -22,7 +22,7 @@ import (
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
 	"github.com/go-delve/delve/service/debugger"
-	"github.com/google/go-dap" // dap
+	"github.com/google/go-dap"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
This change also:
- refactors building helper functions from commands.go into its own gobuild package.
- makes processing untyped launch args (that are implementation-specific and not part of the DAP spec) more robust, verified by additional tests
