### PR TITLE
service/dap: use goroutine id -1 on entry

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -94,9 +94,9 @@ func runTest(t *testing.T, name string, test func(c *daptest.Client, f protest.F
 // - Program stops upon launching  :    << stopped event
 //                                 :  5 << configurationDone
 //                                 :  6 >> threads
-//                                 :  6 << threads (Dummy)
+//                                 :  6 << threads (Current)
 //                                 :  7 >> threads
-//                                 :  7 << threads (Dummy)
+//                                 :  7 << threads (Current)
 //                                 :  8 >> stackTrace
 //                                 :  8 << error (Unable to produce stack trace)
 //                                 :  9 >> stackTrace
@@ -153,9 +153,9 @@ func TestLaunchStopOnEntry(t *testing.T) {
 		stopEvent := client.ExpectStoppedEvent(t)
 		if stopEvent.Seq != 0 ||
 			stopEvent.Body.Reason != "entry" ||
-			stopEvent.Body.ThreadId != 1 ||
+			stopEvent.Body.ThreadId != -1 ||
 			!stopEvent.Body.AllThreadsStopped {
-			t.Errorf("\ngot %#v\nwant Seq=0, Body={Reason=\"entry\", ThreadId=1, AllThreadsStopped=true}", stopEvent)
+			t.Errorf("\ngot %#v\nwant Seq=0, Body={Reason=\"entry\", ThreadId=-1, AllThreadsStopped=true}", stopEvent)
 		}
 		cdResp := client.ExpectConfigurationDoneResponse(t)
 		if cdResp.Seq != 0 || cdResp.RequestSeq != 5 {
@@ -168,8 +168,8 @@ func TestLaunchStopOnEntry(t *testing.T) {
 		if tResp.Seq != 0 || tResp.RequestSeq != 6 || len(tResp.Body.Threads) != 1 {
 			t.Errorf("\ngot %#v\nwant Seq=0, RequestSeq=6 len(Threads)=1", tResp)
 		}
-		if tResp.Body.Threads[0].Id != 1 || tResp.Body.Threads[0].Name != "Dummy" {
-			t.Errorf("\ngot %#v\nwant Id=1, Name=\"Dummy\"", tResp)
+		if tResp.Body.Threads[0].Id != -1 || tResp.Body.Threads[0].Name != "Current" {
+			t.Errorf("\ngot %#v\nwant Id=1, Name=\"Current\"", tResp)
 		}
 
 		// 7 >> threads, << threads
@@ -298,9 +298,9 @@ func TestAttachStopOnEntry(t *testing.T) {
 		stopEvent := client.ExpectStoppedEvent(t)
 		if stopEvent.Seq != 0 ||
 			stopEvent.Body.Reason != "entry" ||
-			stopEvent.Body.ThreadId != 1 ||
+			stopEvent.Body.ThreadId != -1 ||
 			!stopEvent.Body.AllThreadsStopped {
-			t.Errorf("\ngot %#v\nwant Seq=0, Body={Reason=\"entry\", ThreadId=1, AllThreadsStopped=true}", stopEvent)
+			t.Errorf("\ngot %#v\nwant Seq=0, Body={Reason=\"entry\", ThreadId=-1, AllThreadsStopped=true}", stopEvent)
 		}
 		cdResp := client.ExpectConfigurationDoneResponse(t)
 		if cdResp.Seq != 0 || cdResp.RequestSeq != 5 {
@@ -453,7 +453,7 @@ func TestPreSetBreakpoint(t *testing.T) {
 		if stopEvent1.Body.Reason != "breakpoint" ||
 			stopEvent1.Body.ThreadId != 1 ||
 			!stopEvent1.Body.AllThreadsStopped {
-			t.Errorf("got %#v, want Body={Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true}", stopEvent1)
+			t.Errorf("got %#v, want Body={Reason=\"breakpoint\", ThreadId=-1, AllThreadsStopped=true}", stopEvent1)
 		}
 
 		client.ThreadsRequest()


### PR DESCRIPTION
Currently to get "paused on entry" we select goroutine id 1. But that's a hack.

On entry, we get the following:
* launch: no goroutines
* attach: list of goroutines, but not necessarily 1 selected. There could even be none selected (although one goroutine does usually have an associated current thread id.)
In such no-selected cases, current goroutine id appears to be 0, which is recognized and can return a stacktrace. I tried this with dlv cli as well.

Returning 0 doesn't work in stopped events because go-dap marks this field as omitempty.
-1 is a special goroutine id, which means the currently selected goroutine or the current thread if it isn't running a goroutine, so we can use that for now.

Note that -1(0) goroutine produces stacktrace with ???, which trigger the unsupported source request. I guess the editor thinks it's some js-style one-the-fly source if no valid filename is returned. The editor also tries to open this as a tab. I am not sure if this is an improvement over the previous hacky behavior always highlighting goroutine id 1. 

In case of launch we don't have very many options. But in case of attach, we could choose the goroutine of the current thread (if any).

Launch Before:
<img src="https://user-images.githubusercontent.com/51177946/116976267-c3240180-ac75-11eb-8581-a91deb7f3a51.png" alt="Girl in a jacket" width="450">

Launch After:
![image](https://user-images.githubusercontent.com/51177946/116976420-f8305400-ac75-11eb-9f73-4ff70200dc97.png)

Attach After:
![image](https://user-images.githubusercontent.com/51177946/116975868-29f4eb00-ac75-11eb-80db-99a3e42b46d6.png)